### PR TITLE
Fixed autosave amend issue

### DIFF
--- a/XIVLogger/Configuration.cs
+++ b/XIVLogger/Configuration.cs
@@ -610,15 +610,12 @@ namespace XIVLogger
 
                 string path = folder + @"\" + config.autoFileName + ".txt";
 
-                using (System.IO.StreamWriter file = new System.IO.StreamWriter(path, false))
+                using (System.IO.StreamWriter file = new System.IO.StreamWriter(path, true))
                 {
-                    file.WriteLine("Autosave");
-
                     foreach (string message in printedLog)
                     {
                         file.WriteLine(message);
                     }
-
                 }
 
                 if(config.fAutosaveNotif)

--- a/XIVLogger/Configuration.cs
+++ b/XIVLogger/Configuration.cs
@@ -51,6 +51,8 @@ namespace XIVLogger
 
         public string RPAidLog = string.Empty;
 
+        public int autoMsgCounter = 0;
+
         [NonSerialized]
         public DalamudPluginInterface pluginInterface;
 
@@ -460,7 +462,7 @@ namespace XIVLogger
 
         }
 
-        private List<string> prepareLog(int aLastN = 0, bool aTimestamp = false)
+        private List<string> prepareLog(int aLastN = 0, bool aTimestamp = false, bool auto = false)
         {
             ChatConfig activeConfig = config.activeConfig;
 
@@ -577,6 +579,13 @@ namespace XIVLogger
                 result = result.Skip(Math.Max(0, result.Count - aLastN)).ToList();
             }
 
+            // Only return the messages which have been received since the last autosave, and update the counter
+            if (auto)
+            {
+                result = result.Skip(config.autoMsgCounter).ToList();
+                config.autoMsgCounter += result.Count;
+            }
+
             return result;
         }
 
@@ -595,7 +604,7 @@ namespace XIVLogger
             {
                 List<String> printedLog;
 
-                printedLog = prepareLog(aLastN: 0, aTimestamp: config.fTimestamp);
+                printedLog = prepareLog(aLastN: 0, aTimestamp: config.fTimestamp, true);
 
                 string folder;
 


### PR DESCRIPTION
- 'Autosave' is no longer printed each time a save occurs. This is redundant as it will happen each time the autosave is initiated. If such behavior is desired, a special debug logging level could be added.
- Switched file mode from create to append. This will add messages to the end of the existing file instead of truncating it completely. This also solves any issues with crashes emptying the latest logfile.

This fixes #6 and #3